### PR TITLE
Parser directory error

### DIFF
--- a/storyscript/lexer.py
+++ b/storyscript/lexer.py
@@ -19,14 +19,12 @@ keywords = [
 ]
 
 
-class Lexer(object):
+class Lexer:
     def __init__(self, optimize=True):
         self.build(optimize=optimize)
 
     def build(self, **kwargs):
-        self.lexer = lex.lex(object=self,
-                             outputdir=os.path.dirname(__file__),
-                             **kwargs)
+        self.lexer = lex.lex(object=self, outputdir=os.getcwd(), **kwargs)
         self.lexer.filename = None
         self.token_stream = None
 

--- a/storyscript/parser.py
+++ b/storyscript/parser.py
@@ -8,7 +8,7 @@ from .exceptions import ScriptError
 from .lexer import Lexer
 
 
-class Parser(object):
+class Parser:
     def __init__(self, optimize=True, debug=False):
         self.lexer = Lexer(optimize)
         self.tokens = self.lexer.tokens
@@ -16,7 +16,7 @@ class Parser(object):
         self.parser = yacc.yacc(
             module=self,
             start='program',
-            outputdir=os.path.dirname(__file__),
+            outputdir=os.getcwd(),
             optimize=optimize,
             debug=debug
         )

--- a/tests/unittests/test_lexer.py
+++ b/tests/unittests/test_lexer.py
@@ -1,0 +1,23 @@
+import os
+
+from ply import lex
+
+from storyscript.lexer import Lexer
+
+
+def test_lexer_init(mocker):
+    mocker.patch.object(Lexer, 'build')
+    Lexer()
+    Lexer.build.assert_called_with(optimize=True)
+
+
+def test_lexer_build(mocker):
+    mocker.patch.object(os, 'getcwd')
+    mocker.patch.object(Lexer, '__init__', return_value=None)
+    mocker.patch.object(lex, 'lex')
+    lexer = Lexer()
+    lexer.build()
+    lex.lex.assert_called_with(object=lexer, outputdir=os.getcwd())
+    assert lexer.lexer == lex.lex()
+    assert lexer.lexer.filename is None
+    assert lexer.token_stream is None

--- a/tests/unittests/test_parser.py
+++ b/tests/unittests/test_parser.py
@@ -1,0 +1,20 @@
+import os
+
+from ply import yacc
+
+from storyscript.lexer import Lexer
+from storyscript.parser import Parser
+
+
+def test_parser_init(mocker):
+    mocker.patch.object(os, 'getcwd')
+    mocker.patch.object(yacc, 'yacc')
+    mocker.patch.object(Lexer, '__init__', return_value=None)
+    parser = Parser()
+    kwargs = {'module': parser, 'start': 'program', 'optimize': True,
+              'debug': False, 'outputdir': os.getcwd()}
+    yacc.yacc.assert_called_with(**kwargs)
+    Lexer.__init__.assert_called_with(True)
+    assert isinstance(parser.lexer, Lexer)
+    assert parser.tokens == Lexer().tokens
+    assert parser.parser == yacc.yacc()

--- a/tox.ini
+++ b/tox.ini
@@ -25,4 +25,4 @@ commands =
     flake8 \
       --max-complexity=15 \
       --ignore N802,F401 \
-      --exclude=./build,venv,.venv,.tox,dist,docs,storyscript/parsetab.py,storyscript/lextab.py
+      --exclude=./build,venv,.venv,.tox,dist,docs,./parsetab.py,./lextab.py


### PR DESCRIPTION
closes #29

**- What I did**
Yacc and lex use the current working directory, instead of a directory inferred from the python file itself. This is ensures that the output directory always exists.

**- How I did it**
Changed the outputdir argument to use os.getcwd

**- Description for the changelog**
Lexer and parser use the current working directory as output directory for Yacc
