### PR TITLE
fix(cli): cli.parse passes fg keyword to click.style instead of click.echo

### DIFF
--- a/storyscript/cli.py
+++ b/storyscript/cli.py
@@ -52,7 +52,7 @@ class Cli:
         results = App.parse(storypath, debug=debug, as_json=json)
         if not silent:
             if not json:
-                click.echo('Script syntax passed!', fg='green')
+                click.echo(click.style('Script syntax passed!', fg='green'))
                 exit()
 
             for file, story_json in results.items():

--- a/tests/unittests/test_cli.py
+++ b/tests/unittests/test_cli.py
@@ -48,13 +48,15 @@ def test_cli_lexer(mocker, runner, app, echo):
     assert click.echo.call_count == 2
 
 
-def test_cli_parse(runner, echo, app):
+def test_cli_parse(mocker, runner, echo, app):
     """
     Ensures the parse command parses a story
     """
+    mocker.patch.object(click, 'style')
     runner.invoke(Cli.parse, ['/path/to/story'])
     App.parse.assert_called_with('/path/to/story', debug=False, as_json=False)
-    click.echo.assert_called_with('Script syntax passed!', fg='green')
+    click.style.assert_called_with('Script syntax passed!', fg='green')
+    click.echo.assert_called_with(click.style())
 
 
 @mark.parametrize('debug', ['--debug', '-d'])


### PR DESCRIPTION
fixes #27 


**- What I did**
cli.parse now calls click.style with fg instead of click.echo

**- How to verify it**
Parse a story will output a green success message

**- Description for the changelog**
cli.parse passes fg keyword to click.style instead of click.echo
