### PR TITLE
Resolver.path and Resolver.object expect 'paths' in path objects

### DIFF
--- a/storyscript/resolver.py
+++ b/storyscript/resolver.py
@@ -36,7 +36,7 @@ class Resolver:
         with data {'a': {'b': 'value'}} produces 'value'
         """
         try:
-            return reduce(cls._walk, path.split('.'), data)
+            return reduce(cls._walk, path[0].split('.'), data)
         except (KeyError, TypeError):
             return None
 
@@ -81,7 +81,7 @@ class Resolver:
         if object_type == 'string':
             return cls.string(item['string'], data)
         elif object_type == 'path':
-            return cls.path(item['path'], data)
+            return cls.path(item['paths'], data)
         elif object_type == 'regexp':
             return re.compile(item['regexp'])
         elif object_type == 'value':

--- a/tests/integration/test_resolver.py
+++ b/tests/integration/test_resolver.py
@@ -6,9 +6,9 @@ from storyscript.resolver import Resolver
 
 
 @pytest.mark.parametrize('path,data,result', [
-    ('a.b.c', {'a': {'b': {'c': 1}}}, 1),
-    ('a', {'a': {'b': {}}}, {'b': {}}),
-    ('a.1.b', {'a': [1, {'b': 1}]}, 1)
+    (['a.b.c'], {'a': {'b': {'c': 1}}}, 1),
+    (['a'], {'a': {'b': {}}}, {'b': {}}),
+    (['a.1.b'], {'a': [1, {'b': 1}]}, 1)
 ])
 def test_resolve_path(path, data, result):
     assert Resolver.path(path, data) == result
@@ -19,21 +19,21 @@ def test_resolve_path_undefined():
 
 
 @pytest.mark.parametrize('obj,data,result', [
-    ({'$OBJECT': 'path', 'path': 'a'}, {'a': 1}, 1),
+    ({'$OBJECT': 'path', 'paths': ['a']}, {'a': 1}, 1),
     ({'$OBJECT': 'value', 'value': 'a'}, None, 'a'),
     ({'$OBJECT': 'value', 'value': 1}, None, 1),
     ({'$OBJECT': 'expression',
       'expression': '{} == 1',
-      'values': [{'$OBJECT': 'path', 'path': 'a'}]}, {'a': 1}, True),
+      'values': [{'$OBJECT': 'path', 'paths': ['a']}]}, {'a': 1}, True),
     ({'$OBJECT': 'expression',
       'expression': '{} > {}',
-      'values': [{'$OBJECT': 'path', 'path': 'a'},
+      'values': [{'$OBJECT': 'path', 'paths': ['a']},
                  {'$OBJECT': 'value', 'value': 2}]},
      {'a': 1}, False),
     ({'$OBJECT': 'method',
       'method': 'is',
       'left': {'$OBJECT': 'value', 'value': 1},
-      'right': {'$OBJECT': 'path', 'path': 'a'}},
+      'right': {'$OBJECT': 'path', 'paths': ['a']}},
      {'a': 1}, 1),
     (1, None, 1),
     (None, None, None),
@@ -66,10 +66,10 @@ def test_resolve_method(method, left, right, result):
 
 
 @pytest.mark.parametrize('items_list, data, result', [
-    ([{'$OBJECT': 'path', 'path': 'a'}], {'a': 1}, [1]),
-    ([{'$OBJECT': 'path', 'path': 'a'}], {}, [None]),
+    ([{'$OBJECT': 'path', 'paths': ['a']}], {'a': 1}, [1]),
+    ([{'$OBJECT': 'path', 'paths': ['a']}], {}, [None]),
     ([], None, []),
-    ([{'$OBJECT': 'path', 'path': 'abc'},
+    ([{'$OBJECT': 'path', 'paths': ['abc']},
       {'$OBJECT': 'value', 'value': 1}],
      {'abc': 0, 'b': 1}, [0, 1]),
 ])
@@ -78,10 +78,10 @@ def test_resolve_list(items_list, data, result):
 
 
 @pytest.mark.parametrize('dictionary, data, result', [
-    ({'k': {'$OBJECT': 'path', 'path': 'a'}}, {'a': 1}, {'k': 1}),
-    ({'k': {'$OBJECT': 'path', 'path': 'a'}}, {}, {'k': None}),
+    ({'k': {'$OBJECT': 'path', 'paths': ['a']}}, {'a': 1}, {'k': 1}),
+    ({'k': {'$OBJECT': 'path', 'paths': ['a']}}, {}, {'k': None}),
     ({}, None, {}),
-    ({'a': {'$OBJECT': 'path', 'path': 'abc'},
+    ({'a': {'$OBJECT': 'path', 'paths': ['abc']},
       'b': {'$OBJECT': 'value', 'value': 1}},
      {'abc': 0, 'b': 1}, {'a': 0, 'b': 1}),
 ])

--- a/tests/unittests/test_resolver.py
+++ b/tests/unittests/test_resolver.py
@@ -34,23 +34,23 @@ def test_resolver_string_format(data):
 
 
 def test_resolver_path():
-    path = 'a.b.c'
+    path = ['a.b.c']
     data = {'a': {'b': {'c': 'value'}}}
     assert Resolver.path(path, data) == 'value'
 
 
 def test_resolver_path_list():
-    path = 'a.1.b'
+    path = ['a.1.b']
     data = {'a': [0, {'b': 'value'}]}
     assert Resolver.path(path, data) == 'value'
 
 
 def test_resolver_path_key_error():
-    assert Resolver.path('a.b', {}) is None
+    assert Resolver.path(['a.b'], {}) is None
 
 
 def test_resolver_path_type_error():
-    assert Resolver.path('a.b.', {'a': {'b': 'value'}}) is None
+    assert Resolver.path(['a.b.'], {'a': {'b': 'value'}}) is None
 
 
 def test_resolver_dictionary(mocker):
@@ -138,9 +138,9 @@ def test_resolver_object_string(mocker):
 
 def test_resolver_object_path(mocker):
     mocker.patch.object(Resolver, 'path')
-    path = {'$OBJECT': 'path', 'path': 'path'}
+    path = {'$OBJECT': 'path', 'paths': ['example']}
     result = Resolver.object(path, 'data')
-    Resolver.path.assert_called_with('path', 'data')
+    Resolver.path.assert_called_with(['example'], 'data')
     assert result == Resolver.path()
 
 


### PR DESCRIPTION
fixes #55 
Resolver.path and Resolver.object expect 'paths' in path objects

**- What I did**
I changed the path object format expected by Resolver

**- Description for the changelog**
Resolver.path and Resolver.object expect 'paths' in path objects
