### PR TITLE
Support list looping

### DIFF
--- a/storyscript/lexer.py
+++ b/storyscript/lexer.py
@@ -233,6 +233,10 @@ class Lexer:
         r'in(?=\s)'
         return t
 
+    def t_FOR(self, t):
+        r'for(?=\s)'
+        return t
+
     def t_CONTAINS(self, t):
         r'contains(?=\s)'
         return t

--- a/storyscript/lexer.py
+++ b/storyscript/lexer.py
@@ -68,6 +68,7 @@ class Lexer:
         'ELSEIF',
         'END',
         'EXIT',
+        'FOR',
         'HAS',
         'IF',
         'IN',

--- a/storyscript/parser.py
+++ b/storyscript/parser.py
@@ -290,6 +290,10 @@ class Parser:
             suite=p[6]
         )
 
+    def p_stmt_for_item_in_list(self, p):
+        """stmt : FOR PATH IN variable suite"""
+        p[0] = Method('for', self, p.lineno(1), args=[p[2], p[4]], suite=p[5])
+
     def p_expressions(self, p):
         """expressions : expression
                        | expressions AND expression

--- a/storyscript/tree/Comparison.py
+++ b/storyscript/tree/Comparison.py
@@ -21,3 +21,7 @@ class Comparison:
         self._handside_json(result, 'right')
         self._handside_json(result, 'left')
         return result
+
+    def __repr__(self):
+        return 'Comparison({}, {}, {})'.format(self.left, self.method,
+                                               self.right)

--- a/storyscript/tree/Condition.py
+++ b/storyscript/tree/Condition.py
@@ -1,16 +1,19 @@
 class Condition:
 
-    def __init__(self, *args):
-        self.args = args
+    def __init__(self, condition, boolean, consequence, other=None):
+        self.condition = condition
+        self.boolean = boolean
+        self.consequence = consequence
+        self.other = other
 
     def json(self):
         dictionary = {
             '$OBJECT': 'condition',
-            'condition': self.args[0].json(),
-            'is': self.args[1],
-            'then': self.args[2].json(),
-            'else': None
+            'condition': self.condition.json(),
+            'is': self.boolean,
+            'then': self.consequence.json(),
+            'else': self.other
         }
-        if len(self.args) > 3:
-            dictionary['else'] = self.args[3].json()
+        if self.other:
+            dictionary['else'] = self.other.json()
         return dictionary

--- a/storyscript/tree/Condition.py
+++ b/storyscript/tree/Condition.py
@@ -17,3 +17,7 @@ class Condition:
         if self.other:
             dictionary['else'] = self.other.json()
         return dictionary
+
+    def __repr__(self):
+        args = [self.condition, self.boolean, self.consequence, self.other]
+        return 'Condition({}, {}, {}, {})'.format(*args)

--- a/storyscript/tree/Condition.py
+++ b/storyscript/tree/Condition.py
@@ -4,10 +4,13 @@ class Condition:
         self.args = args
 
     def json(self):
-        return {
+        dictionary = {
             '$OBJECT': 'condition',
             'condition': self.args[0].json(),
             'is': self.args[1],
             'then': self.args[2].json(),
-            'else': self.args[3].json() if self.args[3] else None
+            'else': None
         }
+        if len(self.args) > 3:
+            dictionary['else'] = self.args[3].json()
+        return dictionary

--- a/storyscript/tree/Expression.py
+++ b/storyscript/tree/Expression.py
@@ -34,3 +34,6 @@ class Expression:
             'expression': ' '.join(evals),
             'values': values
         }
+
+    def __repr__(self):
+        return 'Expression({})'.format(self.expressions)

--- a/storyscript/tree/Method.py
+++ b/storyscript/tree/Method.py
@@ -44,3 +44,8 @@ class Method:
         if self.exit:
             dictionary['exit'] = str(self.exit)
         return dictionary
+
+    def __repr__(self):
+        args = [self.method, self.parser, self.lineno, self.suite, self.output,
+                self.container, self.args, self.enter, self.exit]
+        return 'Method({}, {}, {}, {}, {}, {}, {}, {}, {})'.format(*args)

--- a/storyscript/tree/Path.py
+++ b/storyscript/tree/Path.py
@@ -29,3 +29,6 @@ class Path:
             '$OBJECT': 'path',
             'paths': self.paths
         }
+
+    def __repr__(self):
+        return 'Path({}, {}, {})'.format(self.parser, self.lineno, self.paths)

--- a/storyscript/tree/Program.py
+++ b/storyscript/tree/Program.py
@@ -27,3 +27,6 @@ class Program:
         script_dictionary = {}
         self.parse_item(script_dictionary, self.story)
         return {'version': version, 'script': script_dictionary}
+
+    def __repr__(self):
+        return 'Program({}, {})'.format(self.parser, self.story)

--- a/storyscript/tree/String.py
+++ b/storyscript/tree/String.py
@@ -32,3 +32,6 @@ class String:
         joined_string = ' '.join(stripped_chunk)
         result['string'] = joined_string
         return result
+
+    def __repr__(self):
+        return 'String({})'.format(self.chunks)

--- a/tests/unittests/test_lexer.py
+++ b/tests/unittests/test_lexer.py
@@ -21,3 +21,7 @@ def test_lexer_build(mocker):
     assert lexer.lexer == lex.lex()
     assert lexer.lexer.filename is None
     assert lexer.token_stream is None
+
+
+def test_lexer_keywords():
+    assert 'FOR' in Lexer.keywords

--- a/tests/unittests/test_lexer.py
+++ b/tests/unittests/test_lexer.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from ply import lex
 
@@ -25,3 +26,10 @@ def test_lexer_build(mocker):
 
 def test_lexer_keywords():
     assert 'FOR' in Lexer.keywords
+
+
+def test_lexer_for(mocker):
+    mocker.patch.object(Lexer, 'build')
+    lexer = Lexer()
+    assert lexer.t_FOR.__doc__ == r'for(?=\s)'
+    assert lexer.t_FOR('token') == 'token'

--- a/tests/unittests/test_parser.py
+++ b/tests/unittests/test_parser.py
@@ -18,3 +18,12 @@ def test_parser_init(mocker):
     assert isinstance(parser.lexer, Lexer)
     assert parser.tokens == Lexer().tokens
     assert parser.parser == yacc.yacc()
+
+
+def test_parser_for_item_in_list(mocker):
+    mocker.patch.object(os, 'getcwd')
+    mocker.patch.object(yacc, 'yacc')
+    mocker.patch.object(Lexer, '__init__', return_value=None)
+    parser = Parser()
+    p = mocker.MagicMock()
+    parser.p_stmt_for_item_in_list(p)

--- a/tests/unittests/tree/test_comparison.py
+++ b/tests/unittests/tree/test_comparison.py
@@ -14,6 +14,10 @@ def test_comparison(comparison):
     assert comparison.right == 'right'
 
 
+def test_comparion_representation(comparison):
+    assert '{}'.format(comparison) == 'Comparison(left, method, right)'
+
+
 def test_comparison_json(comparison):
     result = comparison.json()
     assert result == {'$OBJECT': 'method', 'method': 'method', 'left': 'left',

--- a/tests/unittests/tree/test_condition.py
+++ b/tests/unittests/tree/test_condition.py
@@ -9,19 +9,22 @@ def condition(mocker):
 
 
 def test_condition_init():
-    assert Condition('one', 'two').args == ('one', 'two')
+    condition = Condition('one', 'two', 'three')
+    assert condition.condition == 'one'
+    assert condition.boolean == 'two'
+    assert condition.consequence == 'three'
 
 
 def test_condition(condition):
     assert condition.json() == {
         '$OBJECT': 'condition',
-        'condition': condition.args[0].json(),
-        'is': 'bool',
-        'then': condition.args[2].json(),
+        'condition': condition.condition.json(),
+        'is': condition.boolean,
+        'then': condition.consequence.json(),
         'else': None
     }
 
 
 def test_condition_json_else(mocker, condition):
-    condition.args = tuple(list(condition.args) + [mocker.MagicMock()])
-    assert condition.json()['else'] == condition.args[3].json()
+    condition.other = mocker.MagicMock()
+    assert condition.json()['else'] == condition.other.json()

--- a/tests/unittests/tree/test_condition.py
+++ b/tests/unittests/tree/test_condition.py
@@ -1,25 +1,27 @@
-from pytest import mark
+from pytest import fixture
 
 from storyscript.tree import Condition
 
+
+@fixture
+def condition(mocker):
+    return Condition(mocker.MagicMock(), 'bool', mocker.MagicMock())
 
 
 def test_condition_init():
     assert Condition('one', 'two').args == ('one', 'two')
 
 
-@mark.parametrize('_else',
-                  [0, 1]
-                  )
-def test_condition(mocker, _else):
-    _if = mocker.MagicMock(json=mocker.MagicMock())
-    _then = mocker.MagicMock(json=mocker.MagicMock())
-    _else = mocker.MagicMock(json=mocker.MagicMock()) if _else else None
-    path = Condition(_if, True, _then, _else)
-    assert path.json() == {
+def test_condition(condition):
+    assert condition.json() == {
         '$OBJECT': 'condition',
-        'condition': _if.json(),
-        'is': True,
-        'then': _then.json(),
-        'else': _else.json() if _else else None
+        'condition': condition.args[0].json(),
+        'is': 'bool',
+        'then': condition.args[2].json(),
+        'else': None
     }
+
+
+def test_condition_json_else(mocker, condition):
+    condition.args = tuple(list(condition.args) + [mocker.MagicMock()])
+    assert condition.json()['else'] == condition.args[3].json()

--- a/tests/unittests/tree/test_condition.py
+++ b/tests/unittests/tree/test_condition.py
@@ -3,6 +3,11 @@ from pytest import mark
 from storyscript.tree import Condition
 
 
+
+def test_condition_init():
+    assert Condition('one', 'two').args == ('one', 'two')
+
+
 @mark.parametrize('_else',
                   [0, 1]
                   )

--- a/tests/unittests/tree/test_condition.py
+++ b/tests/unittests/tree/test_condition.py
@@ -28,3 +28,10 @@ def test_condition(condition):
 def test_condition_json_else(mocker, condition):
     condition.other = mocker.MagicMock()
     assert condition.json()['else'] == condition.other.json()
+
+
+def test_condition_representation(condition):
+    condition.condition = 'condition'
+    condition.consequence = 'consequence'
+    string = '{}'.format(condition)
+    assert string == 'Condition(condition, bool, consequence, None)'

--- a/tests/unittests/tree/test_expression.py
+++ b/tests/unittests/tree/test_expression.py
@@ -17,6 +17,10 @@ def test_expression_init(expression):
     assert expression.expressions == [('', 'one')]
 
 
+def test_expression_representation(expression):
+    assert '{}'.format(expression) == "Expression([('', 'one')])"
+
+
 def test_expression_add(expression):
     expression.add('method', 'expression')
     assert expression.expressions[-1] == ('method', 'expression')

--- a/tests/unittests/tree/test_method.py
+++ b/tests/unittests/tree/test_method.py
@@ -15,6 +15,11 @@ def test_method_init(method):
     assert method.exit is None
 
 
+def test_method_representation(method):
+    string = 'Method(method, parser, 1, None, None, None, None, None, None)'
+    assert '{}'.format(method) == string
+
+
 @mark.parametrize('keyword_argument',
                   ['suite', 'output', 'container', 'args']
                   )

--- a/tests/unittests/tree/test_path.py
+++ b/tests/unittests/tree/test_path.py
@@ -10,6 +10,10 @@ def test_path_init(mocker):
     assert path.paths == Path.split()
 
 
+def test_path_repr(path):
+    assert '{}'.format(path) == "Path(parser, line_number, ['path'])"
+
+
 def test_path_split(path):
     assert path.split("a.b['c']") == ['a', 'b', 'c']
 

--- a/tests/unittests/tree/test_program.py
+++ b/tests/unittests/tree/test_program.py
@@ -20,6 +20,10 @@ def test_program_init(parser, program):
     assert program.story == 'story'
 
 
+def test_program_representation(parser, program):
+    assert '{}'.format(program) == 'Program({}, story)'.format(parser)
+
+
 def test_program_parse_item(mocker, method, program):
     mocker.patch.object(Method, 'json')
     result = {}

--- a/tests/unittests/tree/test_string.py
+++ b/tests/unittests/tree/test_string.py
@@ -12,6 +12,10 @@ def test_string_init(string):
     assert string.chunks == ['data']
 
 
+def test_string_representation(string):
+    assert '{}'.format(string) == "String(['data'])"
+
+
 def test_string_add(string):
     string.add('bit')
     assert string.chunks[-1] == 'bit'


### PR DESCRIPTION
Add support for list iterating loops, so that 

closes #64 
```
for item in list
```
is valid Storyscript

**- Description for the changelog**
Storyscript supports for keyword in list iteration
