### PR TITLE
Container first argument fix

### DIFF
--- a/storyscript/parser.py
+++ b/storyscript/parser.py
@@ -168,22 +168,22 @@ class Parser:
         p[0] = Method(*args, **kwargs)
 
     def p_container(self, p):
-        """stmt : PATH PATH args NEWLINE
-                | CONTAINER PATH args NEWLINE"""
+        """stmt : PATH args NEWLINE
+                | CONTAINER args NEWLINE"""
         p[0] = Method(
             'run', self, p.lineno(1),
             container=p[1],
-            args=[p[2]] + (p[3] or [])
+            args=p[2]
         )
 
     def p_container_suite(self, p):
-        """stmt : PATH PATH args suite
-                | CONTAINER PATH args suite"""
+        """stmt : PATH args suite
+                | CONTAINER args suite"""
         p[0] = Method(
             'run', self, p.lineno(1),
             container=p[1],
-            args=[p[2]] + (p[3] or []),
-            suite=p[4]
+            args=p[2],
+            suite=p[3]
         )
 
     def p_story(self, p):
@@ -201,13 +201,13 @@ class Parser:
         p[0] = p[1] if len(p) == 3 else p[2]
 
     def p_stmt_set_path_container(self, p):
-        """stmt : SEQ PATH PATH args NEWLINE
-                | SEQ CONTAINER PATH args NEWLINE"""
+        """stmt : SEQ PATH args NEWLINE
+                | SEQ CONTAINER args NEWLINE"""
         p[0] = Method(
             'run', self, p[1].lineno,
             output=p[1],
             container=p[2],
-            args=[p[3]] + (p[4] or [])
+            args=p[3]
         )
 
     def p_stmt_set_path(self, p):

--- a/tests/unittests/test_conj.py
+++ b/tests/unittests/test_conj.py
@@ -12,5 +12,5 @@ def test_conj(conj):
     assert story['script']['1']['method'] == 'run'
     assert story['script']['1']['container'] == 'Hello'
     assert story['script']['1']['args'] == [
-        'world'
+        {'$OBJECT': 'path', 'paths': ['world']}
     ]

--- a/tests/unittests/test_run.py
+++ b/tests/unittests/test_run.py
@@ -16,7 +16,7 @@ def test_containers():
     assert story['script']['1']['method'] == 'run'
     assert story['script']['1']['container'] == 'owner/repo'
     assert story['script']['1']['args'] == [
-        'arg1',
+        {'$OBJECT': 'path', 'paths': ['arg1']},
         {'$OBJECT': 'path', 'paths': ['arg2']}
     ]
 
@@ -32,7 +32,7 @@ def test_container_comma():
     assert story['script']['1']['method'] == 'run'
     assert story['script']['1']['container'] == 'owner/repo:stable'
     assert story['script']['1']['args'] == [
-        'arg1',
+        {'$OBJECT': 'path', 'paths': ['arg1']},
         {'$OBJECT': 'path', 'paths': ['arg2']}
     ]
 
@@ -47,7 +47,9 @@ def test_containers_long():
     print(dumps(story['script'], indent=2))
     assert story['script']['1']['method'] == 'run'
     assert story['script']['1']['container'] == 'domain.com/owner/repo:latest'
-    assert story['script']['1']['args'] == ['do']
+    assert story['script']['1']['args'] == [
+        {'$OBJECT': 'path', 'paths': ['do']}
+    ]
 
 
 def test_container_suite():

--- a/tests/unittests/test_set.py
+++ b/tests/unittests/test_set.py
@@ -48,12 +48,12 @@ def test_set(script, args):
 
 @pytest.mark.parametrize('script,args', [
     ('x = owner/repo arg --flag foobar -n1',
-     ['arg',
+     [{'$OBJECT': 'path', 'paths': ['arg']},
       '--flag',
       {'$OBJECT': 'path', 'paths': ['foobar']},
       '-n1']),
     ('x = owner/repo run -s=0 --long=1',
-     ['run', '-s', 0, '--long', 1]),
+     [{'$OBJECT': 'path', 'paths': ['run']}, '-s', 0, '--long', 1]),
 ])
 def test_set_container(script, args):
     story = parse(script).json()


### PR DESCRIPTION
> Removing reserved and required position for arg@1 when running a container.

We have found that there are containers that do not require a start command and the container entrypoint should be used. Therefore, removing the required arg@1 as a reserved slot. The result in stories compile in the following way:

```sh
container arg1 arg2
```

```diff
- {"args": ['arg1', {'$OBJECT': 'path', 'paths': ['arg2']}]}
+ {"args": [{'$OBJECT': 'path', 'paths': ['arg1']}, {'$OBJECT': 'path', 'paths': ['arg2']}]}
```

This allows for calling containers like this:

```sh
res = count_letters "hello world"
```
> Note how arg@1 is a string.

```json
{
  "args": [
    {"$OJBECT": "string", "string": "hello world"}
  ]
}
```

----

@Vesuvium the engine needs to take into account that arg@1 is an `$OBJECT` that **may** need to be resolved. Please check the containers manifest of commands to see if the if the `path` lines up with a command. If it does then that is the container command, if it does not then the containers has no command, the entrypoint is used, and the objet is resolved like any other arguments.

> Fixes asyncy/events-microhack-march2018#1