### PR TITLE
fix(parser): Parser.p_stmt_for_item_in_list sets the enter line

### DIFF
--- a/storyscript/parser.py
+++ b/storyscript/parser.py
@@ -302,7 +302,8 @@ class Parser:
 
     def p_stmt_for_item_in_list(self, p):
         """stmt : FOR PATH IN variable suite"""
-        p[0] = Method('for', self, p.lineno(1), args=[p[2], p[4]], suite=p[5])
+        p[0] = Method('for', self, p.lineno(1), args=[p[2], p[4]], suite=p[5],
+                      enter=p[5][0].lineno)
 
     def p_expressions(self, p):
         """expressions : expression

--- a/tests/unittests/test_parser.py
+++ b/tests/unittests/test_parser.py
@@ -23,13 +23,16 @@ def test_parser_init(mocker):
     assert parser.parser == yacc.yacc()
 
 
-def test_parser_for_item_in_list(mocker):
-    mocker.patch.object(os, 'getcwd')
-    mocker.patch.object(yacc, 'yacc')
-    mocker.patch.object(Lexer, '__init__', return_value=None)
+def test_parser_for_item_in_list(patch, magic):
+    patch.object(yacc, 'yacc')
+    patch.init(Lexer)
+    patch.init(Method)
     parser = Parser()
-    p = mocker.MagicMock()
+    p = magic()
     parser.p_stmt_for_item_in_list(p)
+    args = ('for', parser, p.lineno())
+    kwargs = {'args': [p[2], p[4]], 'suite': p[5], 'enter': p[5][0].lineno}
+    Method.__init__.assert_called_with(*args, **kwargs)
 
 
 def test_parser_p_wait(magic, patch):


### PR DESCRIPTION
Syntax tree of for statements has an enter line

fixes #92 