### PR TITLE
Services output

### DIFF
--- a/storyscript/compiler.py
+++ b/storyscript/compiler.py
@@ -171,14 +171,15 @@ class Compiler:
         Translates a command tree to the corresponding line
         """
         line = tree.line()
+        self.set_next_line(line)
         command = tree.node('service_fragment.command')
         if command:
             command = command.child(0)
         arguments = self.arguments(tree.node('service_fragment'))
-        self.set_next_line(line)
         container = tree.child(0).child(0).value
+        output = self.output(tree.node('service_fragment.output'))
         self.add_line('run', line, container=container, command=command,
-                      args=arguments, parent=parent)
+                      args=arguments, parent=parent, output=output)
         self.services.append(container)
 
     def if_block(self, tree, parent=None):

--- a/storyscript/compiler.py
+++ b/storyscript/compiler.py
@@ -130,6 +130,13 @@ class Compiler:
             arguments.append(cls.argument(argument))
         return arguments
 
+    @staticmethod
+    def output(tree):
+        output = []
+        for item in tree.children:
+            output.append(item.value)
+        return output
+
     def add_line(self, method, line, args=None, container=None, command=None,
                  enter=None, exit=None, parent=None):
         """

--- a/storyscript/compiler.py
+++ b/storyscript/compiler.py
@@ -138,7 +138,7 @@ class Compiler:
         return output
 
     def add_line(self, method, line, args=None, container=None, command=None,
-                 enter=None, exit=None, parent=None):
+                 output=None, enter=None, exit=None, parent=None):
         """
         Creates the base dictionary for a given line.
         """
@@ -146,7 +146,7 @@ class Compiler:
             line: {
                 'method': method,
                 'ln': line,
-                'output': None,
+                'output': output,
                 'container': container,
                 'command': command,
                 'args': args,

--- a/storyscript/parser/grammar.py
+++ b/storyscript/parser/grammar.py
@@ -181,10 +181,16 @@ class Grammar:
     def command(self):
         self.ebnf.rule('command', ('ws', 'name'))
 
+    def output(self):
+        rule = '(_WS _AS _WS NAME (_COMMA _WS? NAME)*)'
+        self.ebnf.rule('output', rule, raw=True)
+
     def service_fragment(self):
         self.arguments()
         self.command()
-        self.ebnf.rule('service_fragment', 'command? arguments*', raw=True)
+        self.output()
+        rule = 'command? arguments* output?'
+        self.ebnf.rule('service_fragment', rule, raw=True)
 
     def int_type(self):
         self.ebnf.token('int_type', 'int')

--- a/tests/integration/parser.py
+++ b/tests/integration/parser.py
@@ -133,6 +133,13 @@ def test_parser_service_arguments(parser):
     assert token == Token('DOUBLE_QUOTED', '"value"')
 
 
+def test_parser_service_output(parser):
+    result = parser.parse('container command as request, response\n')
+    node = result.node('start.block.line.service.service_fragment.output')
+    assert node.child(0) == Token('NAME', 'request')
+    assert node.child(1) == Token('NAME', 'response')
+
+
 @mark.parametrize('comment', ['# one', '#one'])
 def test_parser_comment(parser, comment):
     result = parser.parse('{}\n'.format(comment))

--- a/tests/unittests/compiler.py
+++ b/tests/unittests/compiler.py
@@ -212,32 +212,34 @@ def test_compiler_service(patch, compiler, tree):
     """
     Ensures that service trees can be compiled
     """
-    patch.many(Compiler, ['add_line', 'set_next_line', 'arguments'])
+    patch.many(Compiler, ['add_line', 'set_next_line', 'arguments', 'output'])
     tree.node.return_value = None
     compiler.service(tree)
     line = tree.line()
     compiler.set_next_line.assert_called_with(line)
     container = tree.child().child().value
     Compiler.arguments.assert_called_with(tree.node())
+    Compiler.output.assert_called_with(tree.node())
     compiler.add_line.assert_called_with('run', line, container=container,
                                          command=tree.node(), parent=None,
-                                         args=Compiler.arguments())
+                                         args=Compiler.arguments(),
+                                         output=Compiler.output())
     assert compiler.services == [tree.child().child().value]
 
 
 def test_compiler_service_command(patch, compiler, tree):
-    patch.many(Compiler, ['add_line', 'set_next_line', 'arguments'])
+    patch.many(Compiler, ['add_line', 'set_next_line', 'arguments', 'output'])
     compiler.service(tree)
     line = tree.line()
     container = tree.child().child().value
     compiler.add_line.assert_called_with('run', line, container=container,
                                          command=tree.node().child(),
-                                         parent=None,
+                                         parent=None, output=Compiler.output(),
                                          args=Compiler.arguments())
 
 
 def test_compiler_service_parent(patch, compiler, tree):
-    patch.many(Compiler, ['add_line', 'set_next_line', 'arguments'])
+    patch.many(Compiler, ['add_line', 'set_next_line', 'arguments', 'output'])
     tree.node.return_value = None
     compiler.service(tree, parent='1')
     line = tree.line()
@@ -245,7 +247,7 @@ def test_compiler_service_parent(patch, compiler, tree):
     compiler.add_line.assert_called_with('run', line, container=container,
                                          command=tree.node(),
                                          args=Compiler.arguments(),
-                                         parent='1')
+                                         output=Compiler.output(), parent='1')
 
 
 def test_compiler_if_block(patch, compiler):

--- a/tests/unittests/compiler.py
+++ b/tests/unittests/compiler.py
@@ -167,6 +167,12 @@ def test_compiler_arguments(patch, tree):
     assert result == [Compiler.argument()]
 
 
+def test_compiler_output(tree):
+    tree.children = [Token('token', 'output')]
+    result = Compiler.output(tree)
+    assert result == ['output']
+
+
 def test_compiler_add_line(compiler):
     expected = {'1': {'method': 'method', 'ln': '1', 'output': None,
                       'container': None, 'command': None, 'enter': None,

--- a/tests/unittests/compiler.py
+++ b/tests/unittests/compiler.py
@@ -181,8 +181,8 @@ def test_compiler_add_line(compiler):
     assert compiler.lines == expected
 
 
-@mark.parametrize('keywords', ['container', 'command', 'args', 'enter', 'exit',
-                               'parent'])
+@mark.parametrize('keywords', ['container', 'command', 'output', 'args',
+                               'enter', 'exit', 'parent'])
 def test_compiler_add_line_keywords(compiler, keywords):
     compiler.add_line('method', '1', **{keywords: keywords})
     assert compiler.lines['1'][keywords] == keywords

--- a/tests/unittests/parser/grammar.py
+++ b/tests/unittests/parser/grammar.py
@@ -273,12 +273,19 @@ def test_grammar_command(grammar, ebnf):
     ebnf.rule.assert_called_with('command', ('ws', 'name'))
 
 
+def test_grammar_output(grammar, ebnf):
+    grammar.output()
+    rule = '(_WS _AS _WS NAME (_COMMA _WS? NAME)*)'
+    ebnf.rule.assert_called_with('output', rule, raw=True)
+
+
 def test_grammar_service_fragment(patch, grammar, ebnf):
-    patch.many(Grammar, ['arguments', 'command'])
+    patch.many(Grammar, ['arguments', 'command', 'output'])
     grammar.service_fragment()
     assert Grammar.arguments.call_count == 1
     assert Grammar.command.call_count == 1
-    rule = 'command? arguments*'
+    assert Grammar.output.call_count == 1
+    rule = 'command? arguments* output?'
     ebnf.rule.assert_called_with('service_fragment', rule, raw=True)
 
 


### PR DESCRIPTION
Add support for defining services output names.

For example, the following:

```coffee
container stream as request, response
```

will have request and response set in the output property:

```coffee
"output": [
    "request",
    "response"
]
```



closes #123 
