### PR TITLE
fix(compiler): Compiler.output checks whether the tree is None

### DIFF
--- a/storyscript/compiler.py
+++ b/storyscript/compiler.py
@@ -133,8 +133,9 @@ class Compiler:
     @staticmethod
     def output(tree):
         output = []
-        for item in tree.children:
-            output.append(item.value)
+        if tree:
+            for item in tree.children:
+                output.append(item.value)
         return output
 
     def add_line(self, method, line, args=None, container=None, command=None,

--- a/tests/unittests/compiler.py
+++ b/tests/unittests/compiler.py
@@ -173,6 +173,10 @@ def test_compiler_output(tree):
     assert result == ['output']
 
 
+def test_compiler_output_none():
+    assert Compiler.output(None) == []
+
+
 def test_compiler_add_line(compiler):
     expected = {'1': {'method': 'method', 'ln': '1', 'output': None,
                       'container': None, 'command': None, 'enter': None,


### PR DESCRIPTION
fix(compiler): Compiler.output checks whether the tree is None