### PR TITLE
Output argument in CLI

### DIFF
--- a/storyscript/cli.py
+++ b/storyscript/cli.py
@@ -44,7 +44,7 @@ class Cli:
             else:
                 click.echo(click.style('Script syntax passed!', fg='green'))
         if output_file_path:
-            output_file = open(output_file_path, "w")
+            output_file = open(output_file_path, 'w')
             output_file.write(results)
             output_file.close()
 

--- a/storyscript/cli.py
+++ b/storyscript/cli.py
@@ -44,8 +44,9 @@ class Cli:
             else:
                 click.echo(click.style('Script syntax passed!', fg='green'))
         if output_file_path:
-            with open(output_file_path, "w") as output_file:
-                output_file.write(results)
+            output_file = open(output_file_path, "w")
+            output_file.write(results)
+            output_file.close()
 
     @staticmethod
     @main.command()

--- a/storyscript/cli.py
+++ b/storyscript/cli.py
@@ -29,19 +29,23 @@ class Cli:
     @staticmethod
     @main.command()
     @click.argument('storypath')
+    @click.argument('output_file_path', required=False)
     @click.option('--json', '-j', is_flag=True)
     @click.option('--silent', '-s', is_flag=True, help=silent_help)
     @click.option('--ebnf-file', help=ebnf_file_help)
-    def parse(storypath, json, silent, ebnf_file):
+    def parse(storypath, output_file_path, json, silent, ebnf_file):
         """
         Parses stories and prints the resulting json
         """
         results = App.compile(storypath, ebnf_file=ebnf_file)
         if not silent:
-            if not json:
+            if json:
+                click.echo(results)
+            else:
                 click.echo(click.style('Script syntax passed!', fg='green'))
-                exit()
-            click.echo(results)
+        if output_file_path:
+            with open(output_file_path, "w") as output_file:
+                output_file.write(results)
 
     @staticmethod
     @main.command()

--- a/tests/unittests/cli.py
+++ b/tests/unittests/cli.py
@@ -51,6 +51,17 @@ def test_cli_parse(patch, runner, echo, app):
     click.echo.assert_called_with(click.style())
 
 
+def test_cli_parse_output_file(runner, app, tmpdir):
+    """
+    Ensures the parse command outputs to an output file when
+    available. If no file were to be available (e.g. no file was
+    written), this test would throw an error
+    """
+    tmp_file = tmpdir.join('output_file')
+    runner.invoke(Cli.parse, ['/path', str(tmp_file)])
+    tmp_file.read()  # would expect exception if no file written
+
+
 @mark.parametrize('option', ['--silent', '-s'])
 def test_cli_parse_silent(runner, echo, app, option):
     """


### PR DESCRIPTION
**- What I did**
Added ability to include output file with second, optional command line argument for parse

**- How to verify it**
Please see tests. You may also manually test the CLI

**- Description for the changelog**
Add ability to output parse tree to file as second argument to "parse" command in CLI
