### PR TITLE
fix(parser): Parser.parse adds a newline to the given source

### DIFF
--- a/storyscript/parser/parser.py
+++ b/storyscript/parser/parser.py
@@ -44,6 +44,7 @@ class Parser:
         """
         Parses the source string.
         """
+        source = '{}\n'.format(source)
         lark = self.lark()
         try:
             tree = lark.parse(source)

--- a/tests/unittests/parser/parser.py
+++ b/tests/unittests/parser/parser.py
@@ -78,7 +78,7 @@ def test_parser_parse(patch, parser):
     """
     patch.many(Parser, ['lark', 'transformer'])
     result = parser.parse('source')
-    Parser.lark().parse.assert_called_with('source')
+    Parser.lark().parse.assert_called_with('source\n')
     Parser.transformer().transform.assert_called_with(Parser.lark().parse())
     assert result == Parser.transformer().transform()
 


### PR DESCRIPTION
closes #172 

**- What I did**
Fix error due to missing newline at the end of the parse source

**- How I did it**
The parser now adds a newline to the given source

**- Description for the changelog**
Fix error due to missing newline at the end of the parse source
