### PR TITLE
Services output in services list

### DIFF
--- a/storyscript/compiler/compiler.py
+++ b/storyscript/compiler/compiler.py
@@ -14,6 +14,7 @@ class Compiler:
         self.lines = {}
         self.services = []
         self.functions = {}
+        self.outputs = {}
 
     def sorted_lines(self):
         return sorted(self.lines.keys(), key=lambda x: int(x))

--- a/storyscript/compiler/compiler.py
+++ b/storyscript/compiler/compiler.py
@@ -52,6 +52,15 @@ class Compiler:
     def function_output(cls, tree):
         return cls.output(tree.node('function_output.types'))
 
+    def is_output(self, parent_line, service):
+        """
+        Checks whether a service has been defined as output for this block
+        """
+        if parent_line in self.outputs:
+            if service in self.outputs[parent_line]:
+                return True
+        return False
+
     def make_line(self, method, line, args=None, service=None, command=None,
                   function=None, output=None, enter=None, exit=None,
                   parent=None):

--- a/storyscript/compiler/compiler.py
+++ b/storyscript/compiler/compiler.py
@@ -91,7 +91,8 @@ class Compiler:
         if method == 'function':
             self.functions[kwargs['function']] = line
         elif method == 'execute':
-            self.services.append(kwargs['service'])
+            if self.is_output(kwargs['parent'], kwargs['service']) is False:
+                self.services.append(kwargs['service'])
         self.set_next_line(line)
         self.make_line(method, line, **kwargs)
 

--- a/storyscript/compiler/compiler.py
+++ b/storyscript/compiler/compiler.py
@@ -117,6 +117,8 @@ class Compiler:
         arguments = Objects.arguments(tree.node('service_fragment'))
         service = tree.child(0).child(0).value
         output = self.output(tree.node('service_fragment.output'))
+        if output:
+            self.outputs[line] = output
         self.add_line('execute', line, service=service, command=command,
                       args=arguments, parent=parent, output=output)
 

--- a/storyscript/version.py
+++ b/storyscript/version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-version = '0.1.3'
+version = '0.1.4'

--- a/tests/unittests/compiler/compiler.py
+++ b/tests/unittests/compiler/compiler.py
@@ -18,6 +18,7 @@ def test_compiler_init(compiler):
     assert compiler.lines == {}
     assert compiler.services == []
     assert compiler.functions == {}
+    assert compiler.outputs == {}
 
 
 def test_compiler_sorted_lines(compiler):

--- a/tests/unittests/compiler/compiler.py
+++ b/tests/unittests/compiler/compiler.py
@@ -184,10 +184,19 @@ def test_compiler_service_command(patch, compiler, tree):
     compiler.service(tree)
     line = tree.line()
     service = tree.child().child().value
+    assert compiler.outputs[tree.line()] == Compiler.output()
     compiler.add_line.assert_called_with('execute', line, service=service,
                                          command=tree.node().child(),
                                          parent=None, output=Compiler.output(),
                                          args=Objects.arguments())
+
+
+def test_compiler_service_output(patch, compiler, tree):
+    patch.object(Objects, 'arguments')
+    patch.many(Compiler, ['add_line', 'output'])
+    Compiler.output.return_value = None
+    compiler.service(tree)
+    assert compiler.outputs == {}
 
 
 def test_compiler_service_parent(patch, compiler, tree):

--- a/tests/unittests/compiler/compiler.py
+++ b/tests/unittests/compiler/compiler.py
@@ -111,11 +111,24 @@ def test_compiler_add_line_function(patch, compiler):
 
 def test_compiler_add_line_service(patch, compiler):
     """
-    Ensures that a service is registered properly.
+    Ensures that a service is registed in Compiler.services
     """
-    patch.many(Compiler, ['make_line', 'set_next_line'])
-    compiler.add_line('execute', 'line', service='service')
+    patch.many(Compiler, ['make_line', 'set_next_line', 'is_output'])
+    Compiler.is_output.return_value = False
+    compiler.add_line('execute', 'line', service='service', parent='parent')
+    compiler.is_output.assert_called_with('parent', 'service')
     assert compiler.services[0] == 'service'
+
+
+def test_compiler_add_line_service_block_output(patch, compiler):
+    """
+    Ensures that a service is not registered if the current service block
+    has defined it as output
+    """
+    patch.many(Compiler, ['make_line', 'set_next_line', 'is_output'])
+    compiler.outputs = {'line': ['service']}
+    compiler.add_line('execute', 'line', service='service', parent='parent')
+    assert compiler.services == []
 
 
 def test_compiler_add_line_function_call(patch, compiler):

--- a/tests/unittests/compiler/compiler.py
+++ b/tests/unittests/compiler/compiler.py
@@ -68,6 +68,15 @@ def test_compiler_function_output(patch, tree):
     assert result == Compiler.output()
 
 
+def test_compiler_is_output(patch, compiler):
+    compiler.outputs = {'parent_line': ['service']}
+    assert compiler.is_output('parent_line', 'service') is True
+
+
+def test_compiler_is_output_false(patch, compiler):
+    assert compiler.is_output('parent_line', 'service') is False
+
+
 def test_compiler_make_line(compiler):
     expected = {'1': {'method': 'method', 'ln': '1', 'output': None,
                       'function': None, 'service': None, 'command': None,

--- a/tests/unittests/version.py
+++ b/tests/unittests/version.py
@@ -3,4 +3,4 @@ from storyscript.version import version
 
 
 def test_version():
-    assert version == '0.1.3'
+    assert version == '0.1.4'


### PR DESCRIPTION
closes #203 

**- What I did**
The compiler takes note of outputs and checks them before adding a service name to the service list

**- Description for the changelog**
Don't show services output in services list
