### PR TITLE
feat(grammar): Grammar.list recognizes multiline lists

### DIFF
--- a/storyscript/parser/grammar.py
+++ b/storyscript/parser/grammar.py
@@ -154,7 +154,8 @@ class Grammar:
     def list(self):
         self.ebnf.tokens(('comma', ','), ('osb', '['), ('csb', ']'),
                          inline=True)
-        definition = '_OSB (values (_COMMA _WS? values)*)? _CSB'
+        definition = ('_OSB (_NL _INDENT)? (values (_COMMA (_WS|_NL)? '
+                      'values)*)? (_NL _DEDENT)? _CSB')
         self.ebnf.rule('list', definition, raw=True)
 
     def key_value(self):

--- a/tests/unittests/parser/grammar.py
+++ b/tests/unittests/parser/grammar.py
@@ -245,7 +245,8 @@ def test_grammar_list(grammar, ebnf):
     grammar.list()
     tokens = (('comma', ','), ('osb', '['), ('csb', ']'))
     ebnf.tokens.assert_called_with(*tokens, inline=True)
-    definition = '_OSB (values (_COMMA _WS? values)*)? _CSB'
+    definition = ('_OSB (_NL _INDENT)? (values (_COMMA (_WS|_NL)? '
+                  'values)*)? (_NL _DEDENT)? _CSB')
     ebnf.rule.assert_called_with('list', definition, raw=True)
 
 


### PR DESCRIPTION
**- What I did**
Add support for multiline lists

**- Description for the changelog**
Add support for multiline lists
