### PR TITLE
fix(cli): Cli.parse does not write to stdout when an output file is s…

### DIFF
--- a/storyscript/cli.py
+++ b/storyscript/cli.py
@@ -41,13 +41,13 @@ class Cli:
         results = App.compile(storypath, ebnf_file=ebnf_file, debug=debug)
         if not silent:
             if json:
+                if output_file_path:
+                    with open(output_file_path, 'w') as f:
+                        f.write(results)
+                    exit()
                 click.echo(results)
             else:
                 click.echo(click.style('Script syntax passed!', fg='green'))
-        if output_file_path:
-            output_file = open(output_file_path, 'w')
-            output_file.write(results)
-            output_file.close()
 
     @staticmethod
     @main.command()

--- a/tests/unittests/cli.py
+++ b/tests/unittests/cli.py
@@ -58,8 +58,8 @@ def test_cli_parse_output_file(runner, app, tmpdir):
     written), this test would throw an error
     """
     tmp_file = tmpdir.join('output_file')
-    runner.invoke(Cli.parse, ['/path', str(tmp_file)])
-    tmp_file.read()  # would expect exception if no file written
+    runner.invoke(Cli.parse, ['-j', '/path', str(tmp_file)])
+    tmp_file.read()
 
 
 @mark.parametrize('option', ['--silent', '-s'])


### PR DESCRIPTION
closes #184 


**- What I did**
`storyscript parse -j source output` writes only the specified file


**- Description for the changelog**
Fix `storyscript parse -j source output` writing to stdout
