### PR TITLE
Tree nodes attributes

### DIFF
--- a/storyscript/compiler/compiler.py
+++ b/storyscript/compiler/compiler.py
@@ -94,8 +94,8 @@ class Compiler:
         """
         line = tree.line()
         self.lines.set_exit(line)
-        args = Objects.expression(tree.node('elseif_statement'))
-        nested_block = tree.node('nested_block')
+        args = Objects.expression(tree.elseif_statement)
+        nested_block = tree.nested_block
         self.lines.append('elif', line, args=args, enter=nested_block.line(),
                           parent=parent)
         self.subtree(nested_block, parent=line)

--- a/storyscript/compiler/compiler.py
+++ b/storyscript/compiler/compiler.py
@@ -125,10 +125,10 @@ class Compiler:
         Compiles a function and its nested block of code.
         """
         line = tree.line()
-        function = tree.node('function_statement')
+        function = tree.function_statement
         args = Objects.function_arguments(function)
         output = self.function_output(function)
-        nested_block = tree.node('nested_block')
+        nested_block = tree.nested_block
         self.lines.append('function', line, function=function.child(1).value,
                           output=output, args=args, enter=nested_block.line(),
                           parent=parent)

--- a/storyscript/compiler/compiler.py
+++ b/storyscript/compiler/compiler.py
@@ -106,7 +106,7 @@ class Compiler:
         """
         line = tree.line()
         self.lines.set_exit(line)
-        nested_block = tree.node('nested_block')
+        nested_block = tree.nested_block
         self.lines.append('else', line, enter=nested_block.line(),
                           parent=parent)
         self.subtree(nested_block, parent=line)

--- a/storyscript/compiler/compiler.py
+++ b/storyscript/compiler/compiler.py
@@ -77,13 +77,13 @@ class Compiler:
 
     def if_block(self, tree, parent=None):
         line = tree.line()
-        nested_block = tree.node('nested_block')
-        args = Objects.expression(tree.node('if_statement'))
+        nested_block = tree.nested_block
+        args = Objects.expression(tree.if_statement)
         self.lines.append('if', line, args=args, enter=nested_block.line(),
                           parent=parent)
         self.subtree(nested_block, parent=line)
         trees = []
-        for block in [tree.node('elseif_block'), tree.node('else_block')]:
+        for block in [tree.elseif_block, tree.else_block]:
             if block:
                 trees.append(block)
         self.subtrees(*trees)

--- a/storyscript/compiler/compiler.py
+++ b/storyscript/compiler/compiler.py
@@ -51,12 +51,12 @@ class Compiler:
         Compiles a service tree.
         """
         line = tree.line()
-        command = tree.node('service_fragment.command')
+        command = tree.service_fragment.command
         if command:
             command = command.child(0)
-        arguments = Objects.arguments(tree.node('service_fragment'))
+        arguments = Objects.arguments(tree.service_fragment)
         service = tree.child(0).child(0).value
-        output = self.output(tree.node('service_fragment.output'))
+        output = self.output(tree.service_fragment.output)
         if output:
             self.lines.set_output(line, output)
         enter = None

--- a/storyscript/compiler/compiler.py
+++ b/storyscript/compiler/compiler.py
@@ -138,10 +138,9 @@ class Compiler:
         """
         Compiles a service block and the eventual nested block.
         """
-        nested_block = tree.node('nested_block')
-        self.service(tree.node('service'), nested_block, parent)
-        if nested_block:
-            self.subtree(nested_block, parent=tree.line())
+        self.service(tree.service, tree.nested_block, parent)
+        if tree.nested_block:
+            self.subtree(tree.nested_block, parent=tree.line())
 
     def subtrees(self, *trees):
         """

--- a/storyscript/compiler/compiler.py
+++ b/storyscript/compiler/compiler.py
@@ -26,7 +26,7 @@ class Compiler:
     def function_output(cls, tree):
         return cls.output(tree.node('function_output.types'))
 
-    def assignment(self, tree, parent=None):
+    def assignment(self, tree, parent):
         """
         Compiles an assignment tree
         """
@@ -37,7 +37,7 @@ class Compiler:
         ]
         self.lines.append('set', line, args=args, parent=parent)
 
-    def arguments(self, tree, parent=None):
+    def arguments(self, tree, parent):
         """
         Compiles arguments. This is called only for nested arguments.
         """
@@ -65,7 +65,7 @@ class Compiler:
         self.lines.execute(line, service, command, arguments, output, enter,
                            parent)
 
-    def return_statement(self, tree, parent=None):
+    def return_statement(self, tree, parent):
         """
         Compiles a return_statement tree
         """
@@ -75,7 +75,7 @@ class Compiler:
         args = [Objects.values(tree.child(0))]
         self.lines.append('return', line, args=args, parent=parent)
 
-    def if_block(self, tree, parent=None):
+    def if_block(self, tree, parent):
         line = tree.line()
         nested_block = tree.nested_block
         args = Objects.expression(tree.if_statement)
@@ -88,7 +88,7 @@ class Compiler:
                 trees.append(block)
         self.subtrees(*trees)
 
-    def elseif_block(self, tree, parent=None):
+    def elseif_block(self, tree, parent):
         """
         Compiles elseif_block trees
         """
@@ -100,7 +100,7 @@ class Compiler:
                           parent=parent)
         self.subtree(nested_block, parent=line)
 
-    def else_block(self, tree, parent=None):
+    def else_block(self, tree, parent):
         """
         Compiles else_block trees
         """
@@ -111,7 +111,7 @@ class Compiler:
                           parent=parent)
         self.subtree(nested_block, parent=line)
 
-    def foreach_block(self, tree, parent=None):
+    def foreach_block(self, tree, parent):
         line = tree.line()
         args = [Objects.path(tree.foreach_statement)]
         output = self.output(tree.foreach_statement.output)
@@ -120,7 +120,7 @@ class Compiler:
                           parent=parent, output=output)
         self.subtree(nested_block, parent=line)
 
-    def function_block(self, tree, parent=None):
+    def function_block(self, tree, parent):
         """
         Compiles a function and its nested block of code.
         """
@@ -134,7 +134,7 @@ class Compiler:
                           parent=parent)
         self.subtree(nested_block, parent=line)
 
-    def service_block(self, tree, parent=None):
+    def service_block(self, tree, parent):
         """
         Compiles a service block and the eventual nested block.
         """
@@ -158,7 +158,7 @@ class Compiler:
                          'elseif_block', 'else_block', 'foreach_block',
                          'function_block', 'return_statement', 'arguments']
         if tree.data in allowed_nodes:
-            getattr(self, tree.data)(tree, parent=parent)
+            getattr(self, tree.data)(tree, parent)
             return
         self.parse_tree(tree, parent=parent)
 

--- a/storyscript/compiler/compiler.py
+++ b/storyscript/compiler/compiler.py
@@ -32,8 +32,8 @@ class Compiler:
         """
         line = tree.line()
         args = [
-            Objects.path(tree.node('path')),
-            Objects.values(tree.node('assignment_fragment').child(1))
+            Objects.path(tree.path),
+            Objects.values(tree.assignment_fragment.child(1))
         ]
         self.lines.append('set', line, args=args, parent=parent)
 

--- a/storyscript/compiler/compiler.py
+++ b/storyscript/compiler/compiler.py
@@ -113,9 +113,9 @@ class Compiler:
 
     def foreach_block(self, tree, parent=None):
         line = tree.line()
-        args = [Objects.path(tree.node('foreach_statement'))]
-        output = self.output(tree.node('foreach_statement.output'))
-        nested_block = tree.node('nested_block')
+        args = [Objects.path(tree.foreach_statement)]
+        output = self.output(tree.foreach_statement.output)
+        nested_block = tree.nested_block
         self.lines.append('for', line, args=args, enter=nested_block.line(),
                           parent=parent, output=output)
         self.subtree(nested_block, parent=line)

--- a/storyscript/parser/tree.py
+++ b/storyscript/parser/tree.py
@@ -40,3 +40,6 @@ class Tree(LarkTree):
             if isinstance(child, Token):
                 return str(child.line)
             return child.line()
+
+    def __getattr__(self, attribute):
+        return self.node(attribute)

--- a/tests/unittests/compiler/compiler.py
+++ b/tests/unittests/compiler/compiler.py
@@ -47,9 +47,9 @@ def test_compiler_function_output(patch, tree):
 def test_compiler_assignment(patch, compiler, lines, tree):
     patch.many(Objects, ['path', 'values'])
     compiler.assignment(tree)
-    assert tree.node.call_count == 2
-    Objects.path.assert_called_with(tree.node())
-    Objects.values.assert_called_with(tree.node().child())
+    Objects.path.assert_called_with(tree.path)
+    tree.assignment_fragment.child.assert_called_with(1)
+    Objects.values.assert_called_with(tree.assignment_fragment.child())
     args = [Objects.path(), Objects.values()]
     lines.append.assert_called_with('set', tree.line(), args=args, parent=None)
 

--- a/tests/unittests/compiler/compiler.py
+++ b/tests/unittests/compiler/compiler.py
@@ -193,12 +193,12 @@ def test_compiler_elseif_block(patch, compiler, lines, tree):
     patch.object(Compiler, 'subtree')
     compiler.elseif_block(tree)
     lines.set_exit.assert_called_with(tree.line())
-    assert tree.node.call_count == 2
-    Objects.expression.assert_called_with(tree.node())
+    Objects.expression.assert_called_with(tree.elseif_statement)
     args = Objects.expression()
     lines.append.assert_called_with('elif', tree.line(), args=args,
-                                    enter=tree.node().line(), parent=None)
-    compiler.subtree.assert_called_with(tree.node(), parent=tree.line())
+                                    enter=tree.nested_block.line(),
+                                    parent=None)
+    compiler.subtree.assert_called_with(tree.nested_block, parent=tree.line())
 
 
 def test_compiler_elseif_block_parent(patch, compiler, lines, tree):
@@ -207,7 +207,7 @@ def test_compiler_elseif_block_parent(patch, compiler, lines, tree):
     compiler.elseif_block(tree, parent='1')
     args = Objects.expression()
     lines.append.assert_called_with('elif', tree.line(), args=args,
-                                    enter=tree.node().line(), parent='1')
+                                    enter=tree.nested_block.line(), parent='1')
 
 
 def test_compiler_else_block(patch, compiler, lines, tree):

--- a/tests/unittests/compiler/compiler.py
+++ b/tests/unittests/compiler/compiler.py
@@ -214,16 +214,16 @@ def test_compiler_else_block(patch, compiler, lines, tree):
     patch.object(Compiler, 'subtree')
     compiler.else_block(tree)
     lines.set_exit.assert_called_with(tree.line())
-    lines.append.assert_called_with('else', tree.line(),
-                                    enter=tree.node().line(), parent=None)
-    compiler.subtree.assert_called_with(tree.node(), parent=tree.line())
+    lines.append.assert_called_with('else', tree.line(), parent=None,
+                                    enter=tree.nested_block.line())
+    compiler.subtree.assert_called_with(tree.nested_block, parent=tree.line())
 
 
 def test_compiler_else_block_parent(patch, compiler, lines, tree):
     patch.object(Compiler, 'subtree')
     compiler.else_block(tree, parent='1')
     lines.append.assert_called_with('else', tree.line(),
-                                    enter=tree.node().line(), parent='1')
+                                    enter=tree.nested_block.line(), parent='1')
 
 
 def test_compiler_foreach_block(patch, compiler, lines, tree):

--- a/tests/unittests/compiler/compiler.py
+++ b/tests/unittests/compiler/compiler.py
@@ -253,25 +253,28 @@ def test_compiler_function_block(patch, compiler, lines, tree):
     patch.object(Objects, 'function_arguments')
     patch.many(Compiler, ['subtree', 'function_output'])
     compiler.function_block(tree)
-    Objects.function_arguments.assert_called_with(tree.node())
-    compiler.function_output.assert_called_with(tree.node())
+    statement = tree.function_statement
+    Objects.function_arguments.assert_called_with(statement)
+    compiler.function_output.assert_called_with(statement)
     lines.append.assert_called_with('function', tree.line(),
-                                    function=tree.node().child().value,
+                                    function=statement.child().value,
                                     args=Objects.function_arguments(),
                                     output=compiler.function_output(),
-                                    enter=tree.node().line(), parent=None)
-    compiler.subtree.assert_called_with(tree.node(), parent=tree.line())
+                                    enter=tree.nested_block.line(),
+                                    parent=None)
+    compiler.subtree.assert_called_with(tree.nested_block, parent=tree.line())
 
 
 def test_compiler_function_block_parent(patch, compiler, lines, tree):
     patch.object(Objects, 'function_arguments')
     patch.many(Compiler, ['subtree', 'function_output'])
     compiler.function_block(tree, parent='1')
+    statement = tree.function_statement
     lines.append.assert_called_with('function', tree.line(),
-                                    function=tree.node().child().value,
+                                    function=statement.child().value,
                                     args=Objects.function_arguments(),
                                     output=compiler.function_output(),
-                                    enter=tree.node().line(), parent='1')
+                                    enter=tree.nested_block.line(), parent='1')
 
 
 def test_compiler_service_block(patch, compiler, tree):

--- a/tests/unittests/compiler/compiler.py
+++ b/tests/unittests/compiler/compiler.py
@@ -46,17 +46,10 @@ def test_compiler_function_output(patch, tree):
 
 def test_compiler_assignment(patch, compiler, lines, tree):
     patch.many(Objects, ['path', 'values'])
-    compiler.assignment(tree)
+    compiler.assignment(tree, '1')
     Objects.path.assert_called_with(tree.path)
     tree.assignment_fragment.child.assert_called_with(1)
     Objects.values.assert_called_with(tree.assignment_fragment.child())
-    args = [Objects.path(), Objects.values()]
-    lines.append.assert_called_with('set', tree.line(), args=args, parent=None)
-
-
-def test_compiler_assignment_parent(patch, compiler, lines, tree):
-    patch.many(Objects, ['path', 'values'])
-    compiler.assignment(tree, parent='1')
     args = [Objects.path(), Objects.values()]
     lines.append.assert_called_with('set', tree.line(), args=args, parent='1')
 
@@ -65,7 +58,7 @@ def test_compiler_arguments(patch, compiler, lines, tree):
     patch.object(Objects, 'arguments')
     lines.last.return_value = '1'
     lines.lines = {'1': {'method': 'execute', 'args': ['args']}}
-    compiler.arguments(tree)
+    compiler.arguments(tree, '0')
     Objects.arguments.assert_called_with(tree)
     assert lines.lines['1']['args'] == ['args'] + Objects.arguments()
 
@@ -78,7 +71,7 @@ def test_compiler_arguments_not_execute(patch, compiler, lines, tree):
     lines.last.return_value = '1'
     lines.lines = {'1': {'method': 'whatever'}}
     with raises(StoryscriptSyntaxError):
-        compiler.arguments(tree)
+        compiler.arguments(tree, '0')
 
 
 def test_compiler_service(patch, compiler, lines, tree):
@@ -136,12 +129,12 @@ def test_compiler_service_no_output(patch, compiler, lines, tree):
 
 def test_compiler_return_statement(compiler, tree):
     with raises(StoryscriptSyntaxError):
-        compiler.return_statement(tree)
+        compiler.return_statement(tree, None)
 
 
 def test_compiler_return_statement_parent(patch, compiler, lines, tree):
     patch.object(Objects, 'values')
-    compiler.return_statement(tree, parent='1')
+    compiler.return_statement(tree, '1')
     line = tree.line()
     Objects.values.assert_called_with(tree.child())
     lines.append.assert_called_with('return', line, args=[Objects.values()],
@@ -153,30 +146,20 @@ def test_compiler_if_block(patch, compiler, lines, tree):
     patch.object(Compiler, 'subtree')
     tree.elseif_block = None
     tree.else_block = None
-    compiler.if_block(tree)
+    compiler.if_block(tree, '1')
     Objects.expression.assert_called_with(tree.if_statement)
     nested_block = tree.nested_block
     args = Objects.expression()
     lines.append.assert_called_with('if', tree.line(), args=args,
-                                    enter=nested_block.line(), parent=None)
-    compiler.subtree.assert_called_with(nested_block, parent=tree.line())
-
-
-def test_compiler_if_block_parent(patch, compiler, lines, tree):
-    patch.object(Objects, 'expression')
-    patch.object(Compiler, 'subtree')
-    compiler.if_block(tree, parent='1')
-    nested_block = tree.nested_block
-    args = Objects.expression()
-    lines.append.assert_called_with('if', tree.line(), args=args,
                                     enter=nested_block.line(), parent='1')
+    compiler.subtree.assert_called_with(nested_block, parent=tree.line())
 
 
 def test_compiler_if_block_with_elseif(patch, compiler, tree):
     patch.object(Objects, 'expression')
     patch.many(Compiler, ['subtree', 'subtrees'])
     tree.else_block = None
-    compiler.if_block(tree)
+    compiler.if_block(tree, '1')
     compiler.subtrees.assert_called_with(tree.elseif_block)
 
 
@@ -184,75 +167,49 @@ def test_compiler_if_block_with_else(patch, compiler, tree):
     patch.object(Objects, 'expression')
     patch.many(Compiler, ['subtree', 'subtrees'])
     tree.elseif_block = None
-    compiler.if_block(tree)
+    compiler.if_block(tree, '1')
     compiler.subtrees.assert_called_with(tree.else_block)
 
 
 def test_compiler_elseif_block(patch, compiler, lines, tree):
     patch.object(Objects, 'expression')
     patch.object(Compiler, 'subtree')
-    compiler.elseif_block(tree)
+    compiler.elseif_block(tree, '1')
     lines.set_exit.assert_called_with(tree.line())
     Objects.expression.assert_called_with(tree.elseif_statement)
     args = Objects.expression()
     lines.append.assert_called_with('elif', tree.line(), args=args,
                                     enter=tree.nested_block.line(),
-                                    parent=None)
+                                    parent='1')
     compiler.subtree.assert_called_with(tree.nested_block, parent=tree.line())
-
-
-def test_compiler_elseif_block_parent(patch, compiler, lines, tree):
-    patch.object(Objects, 'expression')
-    patch.object(Compiler, 'subtree')
-    compiler.elseif_block(tree, parent='1')
-    args = Objects.expression()
-    lines.append.assert_called_with('elif', tree.line(), args=args,
-                                    enter=tree.nested_block.line(), parent='1')
 
 
 def test_compiler_else_block(patch, compiler, lines, tree):
     patch.object(Compiler, 'subtree')
-    compiler.else_block(tree)
+    compiler.else_block(tree, '1')
     lines.set_exit.assert_called_with(tree.line())
-    lines.append.assert_called_with('else', tree.line(), parent=None,
+    lines.append.assert_called_with('else', tree.line(), parent='1',
                                     enter=tree.nested_block.line())
     compiler.subtree.assert_called_with(tree.nested_block, parent=tree.line())
-
-
-def test_compiler_else_block_parent(patch, compiler, lines, tree):
-    patch.object(Compiler, 'subtree')
-    compiler.else_block(tree, parent='1')
-    lines.append.assert_called_with('else', tree.line(),
-                                    enter=tree.nested_block.line(), parent='1')
 
 
 def test_compiler_foreach_block(patch, compiler, lines, tree):
     patch.object(Objects, 'path')
     patch.many(Compiler, ['subtree', 'output'])
-    compiler.foreach_block(tree)
+    compiler.foreach_block(tree, '1')
     Objects.path.assert_called_with(tree.foreach_statement)
     compiler.output.assert_called_with(tree.foreach_statement.output)
     args = [Objects.path()]
     lines.append.assert_called_with('for', tree.line(), args=args,
                                     enter=tree.nested_block.line(),
-                                    output=Compiler.output(), parent=None)
-    compiler.subtree.assert_called_with(tree.nested_block, parent=tree.line())
-
-
-def test_compiler_foreach_block_parent(patch, compiler, lines, tree):
-    patch.object(Objects, 'path')
-    patch.many(Compiler, ['subtree', 'output'])
-    compiler.foreach_block(tree, parent='1')
-    args = [Objects.path()]
-    lines.append.assert_called_with('for', tree.line(), args=args,
-                                    enter=tree.nested_block.line(),
                                     output=Compiler.output(), parent='1')
+    compiler.subtree.assert_called_with(tree.nested_block, parent=tree.line())
 
 
 def test_compiler_function_block(patch, compiler, lines, tree):
     patch.object(Objects, 'function_arguments')
     patch.many(Compiler, ['subtree', 'function_output'])
-    compiler.function_block(tree)
+    compiler.function_block(tree, '1')
     statement = tree.function_statement
     Objects.function_arguments.assert_called_with(statement)
     compiler.function_output.assert_called_with(statement)
@@ -261,32 +218,20 @@ def test_compiler_function_block(patch, compiler, lines, tree):
                                     args=Objects.function_arguments(),
                                     output=compiler.function_output(),
                                     enter=tree.nested_block.line(),
-                                    parent=None)
+                                    parent='1')
     compiler.subtree.assert_called_with(tree.nested_block, parent=tree.line())
-
-
-def test_compiler_function_block_parent(patch, compiler, lines, tree):
-    patch.object(Objects, 'function_arguments')
-    patch.many(Compiler, ['subtree', 'function_output'])
-    compiler.function_block(tree, parent='1')
-    statement = tree.function_statement
-    lines.append.assert_called_with('function', tree.line(),
-                                    function=statement.child().value,
-                                    args=Objects.function_arguments(),
-                                    output=compiler.function_output(),
-                                    enter=tree.nested_block.line(), parent='1')
 
 
 def test_compiler_service_block(patch, compiler, tree):
     patch.object(Compiler, 'service')
     tree.node.return_value = None
-    compiler.service_block(tree)
-    Compiler.service.assert_called_with(tree.service, tree.nested_block, None)
+    compiler.service_block(tree, '1')
+    Compiler.service.assert_called_with(tree.service, tree.nested_block, '1')
 
 
 def test_compiler_service_block_nested_block(patch, compiler, tree):
     patch.many(Compiler, ['subtree', 'service'])
-    compiler.service_block(tree)
+    compiler.service_block(tree, '1')
     Compiler.subtree.assert_called_with(tree.nested_block, parent=tree.line())
 
 
@@ -299,14 +244,14 @@ def test_compiler_subtree(patch, compiler, method_name):
     tree = Tree(method_name, [])
     compiler.subtree(tree)
     method = getattr(compiler, method_name)
-    method.assert_called_with(tree, parent=None)
+    method.assert_called_with(tree, None)
 
 
 def test_compiler_subtree_parent(patch, compiler):
     patch.object(Compiler, 'assignment')
     tree = Tree('assignment', [])
     compiler.subtree(tree, parent='1')
-    compiler.assignment.assert_called_with(tree, parent='1')
+    compiler.assignment.assert_called_with(tree, '1')
 
 
 def test_compiler_subtrees(patch, compiler, tree):

--- a/tests/unittests/compiler/compiler.py
+++ b/tests/unittests/compiler/compiler.py
@@ -148,47 +148,44 @@ def test_compiler_return_statement_parent(patch, compiler, lines, tree):
                                     parent='1')
 
 
-def test_compiler_if_block(patch, compiler, lines):
+def test_compiler_if_block(patch, compiler, lines, tree):
     patch.object(Objects, 'expression')
     patch.object(Compiler, 'subtree')
-    tree = Tree('if_block', [Tree('if_statement', []),
-                             Tree('nested_block', [])])
+    tree.elseif_block = None
+    tree.else_block = None
     compiler.if_block(tree)
-    Objects.expression.assert_called_with(tree.node('if_statement'))
-    nested_block = tree.node('nested_block')
+    Objects.expression.assert_called_with(tree.if_statement)
+    nested_block = tree.nested_block
     args = Objects.expression()
     lines.append.assert_called_with('if', tree.line(), args=args,
                                     enter=nested_block.line(), parent=None)
     compiler.subtree.assert_called_with(nested_block, parent=tree.line())
 
 
-def test_compiler_if_block_parent(patch, compiler, lines):
+def test_compiler_if_block_parent(patch, compiler, lines, tree):
     patch.object(Objects, 'expression')
     patch.object(Compiler, 'subtree')
-    tree = Tree('if_block', [Tree('if_statement', []),
-                             Tree('nested_block', [])])
     compiler.if_block(tree, parent='1')
-    nested_block = tree.node('nested_block')
+    nested_block = tree.nested_block
     args = Objects.expression()
     lines.append.assert_called_with('if', tree.line(), args=args,
                                     enter=nested_block.line(), parent='1')
 
 
-def test_compiler_if_block_with_elseif(patch, compiler):
+def test_compiler_if_block_with_elseif(patch, compiler, tree):
     patch.object(Objects, 'expression')
     patch.many(Compiler, ['subtree', 'subtrees'])
-    tree = Tree('if_block', [Tree('nested_block', []),
-                             Tree('elseif_block', [])])
+    tree.else_block = None
     compiler.if_block(tree)
-    compiler.subtrees.assert_called_with(tree.node('elseif_block'))
+    compiler.subtrees.assert_called_with(tree.elseif_block)
 
 
-def test_compiler_if_block_with_else(patch, compiler):
+def test_compiler_if_block_with_else(patch, compiler, tree):
     patch.object(Objects, 'expression')
     patch.many(Compiler, ['subtree', 'subtrees'])
-    tree = Tree('if_block', [Tree('nested_block', []), Tree('else_block', [])])
+    tree.elseif_block = None
     compiler.if_block(tree)
-    compiler.subtrees.assert_called_with(tree.node('else_block'))
+    compiler.subtrees.assert_called_with(tree.else_block)
 
 
 def test_compiler_elseif_block(patch, compiler, lines, tree):

--- a/tests/unittests/compiler/compiler.py
+++ b/tests/unittests/compiler/compiler.py
@@ -281,13 +281,13 @@ def test_compiler_service_block(patch, compiler, tree):
     patch.object(Compiler, 'service')
     tree.node.return_value = None
     compiler.service_block(tree)
-    Compiler.service.assert_called_with(tree.node(), tree.node(), None)
+    Compiler.service.assert_called_with(tree.service, tree.nested_block, None)
 
 
 def test_compiler_service_block_nested_block(patch, compiler, tree):
     patch.many(Compiler, ['subtree', 'service'])
     compiler.service_block(tree)
-    Compiler.subtree.assert_called_with(tree.node(), parent=tree.line())
+    Compiler.subtree.assert_called_with(tree.nested_block, parent=tree.line())
 
 
 @mark.parametrize('method_name', [

--- a/tests/unittests/compiler/compiler.py
+++ b/tests/unittests/compiler/compiler.py
@@ -91,9 +91,10 @@ def test_compiler_service(patch, compiler, lines, tree):
     compiler.service(tree, None, 'parent')
     line = tree.line()
     service = tree.child().child().value
-    Objects.arguments.assert_called_with(tree.node())
-    Compiler.output.assert_called_with(tree.node())
-    lines.execute.assert_called_with(line, service, tree.node(),
+    command = tree.service_fragment.command.child()
+    Objects.arguments.assert_called_with(tree.service_fragment)
+    Compiler.output.assert_called_with(tree.service_fragment.output)
+    lines.execute.assert_called_with(line, service, command,
                                      Objects.arguments(), Compiler.output(),
                                      None, 'parent')
 
@@ -104,8 +105,9 @@ def test_compiler_service_command(patch, compiler, lines, tree):
     compiler.service(tree, None, 'parent')
     line = tree.line()
     service = tree.child().child().value
+    command = tree.service_fragment.command.child()
     lines.set_output.assert_called_with(line, Compiler.output())
-    lines.execute.assert_called_with(line, service, tree.node().child(),
+    lines.execute.assert_called_with(line, service, command,
                                      Objects.arguments(), Compiler.output(),
                                      None, 'parent')
 
@@ -118,7 +120,8 @@ def test_compiler_service_nested_block(patch, magic, compiler, lines, tree):
     compiler.service(tree, nested_block, 'parent')
     line = tree.line()
     service = tree.child().child().value
-    lines.execute.assert_called_with(line, service, tree.node(),
+    command = tree.service_fragment.command.child()
+    lines.execute.assert_called_with(line, service, command,
                                      Objects.arguments(), Compiler.output(),
                                      nested_block.line(), 'parent')
 

--- a/tests/unittests/compiler/compiler.py
+++ b/tests/unittests/compiler/compiler.py
@@ -230,13 +230,13 @@ def test_compiler_foreach_block(patch, compiler, lines, tree):
     patch.object(Objects, 'path')
     patch.many(Compiler, ['subtree', 'output'])
     compiler.foreach_block(tree)
-    Objects.path.assert_called_with(tree.node())
-    compiler.output.assert_called_with(tree.node())
+    Objects.path.assert_called_with(tree.foreach_statement)
+    compiler.output.assert_called_with(tree.foreach_statement.output)
     args = [Objects.path()]
     lines.append.assert_called_with('for', tree.line(), args=args,
-                                    enter=tree.node().line(),
+                                    enter=tree.nested_block.line(),
                                     output=Compiler.output(), parent=None)
-    compiler.subtree.assert_called_with(tree.node(), parent=tree.line())
+    compiler.subtree.assert_called_with(tree.nested_block, parent=tree.line())
 
 
 def test_compiler_foreach_block_parent(patch, compiler, lines, tree):
@@ -245,7 +245,7 @@ def test_compiler_foreach_block_parent(patch, compiler, lines, tree):
     compiler.foreach_block(tree, parent='1')
     args = [Objects.path()]
     lines.append.assert_called_with('for', tree.line(), args=args,
-                                    enter=tree.node().line(),
+                                    enter=tree.nested_block.line(),
                                     output=Compiler.output(), parent='1')
 
 

--- a/tests/unittests/parser/tree.py
+++ b/tests/unittests/parser/tree.py
@@ -60,3 +60,11 @@ def test_tree_child_overflow():
 def test_tree_line():
     tree = Tree('outer', [Tree('path', [Token('WORD', 'word', line=1)])])
     assert tree.line() == '1'
+
+
+def test_tree_attributes(patch):
+    patch.object(Tree, 'node')
+    tree = Tree('master', [])
+    result = tree.branch
+    Tree.node.assert_called_with('branch')
+    assert result == Tree.node()


### PR DESCRIPTION
closes #166 

**- What I did**
The tree module exposes tree nodes through properties
Improvements to the compiler handling of parents


**- Description for the changelog**
The tree module exposes tree nodes through properties
